### PR TITLE
Makes format detection more robust regarding whitespace

### DIFF
--- a/ClientApp/src/components/misc/Getter.js
+++ b/ClientApp/src/components/misc/Getter.js
@@ -23,9 +23,9 @@ export class Getter extends Component {
 
   tryFormat() {
     try {
-      if (this.state.pasteText.startsWith('{')) {
+      if (this.state.pasteText.trim().startsWith('{')) {
         this.setState({ pasteText: this.formatJson(this.state.pasteText, 2) });
-      } else if (this.state.pasteText.startsWith('<')) {
+      } else if (this.state.pasteText.trim().startsWith('<')) {
         this.setState({ pasteText: this.formatXml(this.state.pasteText, 2) });
       } else if (this.state.pasteText.length === 5000) {
         this.setState({ pasteText: this.formatIje(this.state.pasteText) });

--- a/ClientApp/src/components/misc/info/Property.js
+++ b/ClientApp/src/components/misc/info/Property.js
@@ -157,9 +157,9 @@ export class Property extends Component {
 
   tryFormat(content) {
     try {
-      if (content.startsWith('{') || content.startsWith('[')) {
+      if (content.trim().startsWith('{') || content.trim().startsWith('[')) {
         return this.formatJson(content, 2);
-      } else if (content.startsWith('<')) {
+      } else if (content.trim().startsWith('<')) {
         return this.formatXml(content, 2);
       }
     } catch (err) {}

--- a/Controllers/EndpointsController.cs
+++ b/Controllers/EndpointsController.cs
@@ -69,11 +69,11 @@ namespace canary.Controllers
             }
             if (!String.IsNullOrEmpty(input))
             {
-                if (input.StartsWith("<")) // XML?
+                if (input.Trim().StartsWith("<")) // XML?
                 {
                     (record, issues) = Record.CheckGetXml(input, "yes" == "yes" ? true : false); // TODO
                 }
-                else if (input.StartsWith("{")) // JSON?
+                else if (input.Trim().StartsWith("{")) // JSON?
                 {
                     (record, issues) = Record.CheckGetJson(input, "yes" == "yes" ? true : false);
                 }

--- a/Controllers/RecordsController.cs
+++ b/Controllers/RecordsController.cs
@@ -84,11 +84,11 @@ namespace canary.Controllers
             }
             if (!String.IsNullOrEmpty(input))
             {
-                if (input.StartsWith("<")) // XML?
+                if (input.Trim().StartsWith("<")) // XML?
                 {
                     return Record.CheckGetXml(input, "yes" == "yes" ? true : false); // TODO strict mode
                 }
-                else if (input.StartsWith("{")) // JSON?
+                else if (input.Trim().StartsWith("{")) // JSON?
                 {
                     return Record.CheckGetJson(input, "yes" == "yes" ? true : false);
                 }


### PR DESCRIPTION
This pull request allows Canary to correctly detect JSON and XML files even if they contain leading whitespace