### PR TITLE
Add FHIR message validation to Canary

### DIFF
--- a/canary/ClientApp/src/App.js
+++ b/canary/ClientApp/src/App.js
@@ -11,6 +11,7 @@ import { FHIRCreator } from './components/tools/FHIRCreator';
 import { FHIRInspector } from './components/tools/FHIRInspector';
 import { FHIRValidator } from './components/tools/FHIRValidator';
 import { FHIRValidatorReturn } from './components/tools/FHIRValidatorReturn';
+import { FHIRMessageValidator } from './components/tools/FHIRMessageValidator';
 import { IJEInspector } from './components/tools/IJEInspector';
 import { RecordConverter } from './components/tools/RecordConverter';
 import { RecordGenerator } from './components/tools/RecordGenerator';
@@ -36,6 +37,7 @@ export default class App extends Component {
           <Route path="/tool-fhir-creator" component={FHIRCreator} />
           <Route path="/tool-fhir-validator" component={FHIRValidator} />
           <Route path="/tool-fhir-validator-return" component={FHIRValidatorReturn} />
+          <Route path="/tool-fhir-message-validator" component={FHIRMessageValidator} />
           <Route path="/tool-ije-inspector" component={IJEInspector} />
           <Route path="/tool-record-converter" component={RecordConverter} />
           <Route path="/tool-record-generator" component={RecordGenerator} />

--- a/canary/ClientApp/src/components/dashboard/Dashboard.js
+++ b/canary/ClientApp/src/components/dashboard/Dashboard.js
@@ -98,6 +98,12 @@ export class Dashboard extends Component {
                   description="Check a given FHIR VRDR Coded Return Bundle for syntax/structural issues."
                   route="tool-fhir-validator-return"
                 />
+                < DashboardItem
+                  icon = "envelope"
+                  title = "Validate FHIR VRDR Messages"
+                  description = "Check a given FHIR VRDR Message for syntax/structural issues."
+                  route = "tool-fhir-message-validator"
+                />
                 <DashboardItem
                   icon="random"
                   title="Death Record Format Converter"

--- a/canary/ClientApp/src/components/misc/Getter.js
+++ b/canary/ClientApp/src/components/misc/Getter.js
@@ -87,6 +87,8 @@ export class Getter extends Component {
       var endpoint = '';
       if (this.props.returnType) {
         endpoint = '/records/return/new';
+      } else if(this.props.messageValidation) {
+        endpoint = '/records/message/new'
       } else {
         endpoint = '/records/new';
       }
@@ -199,6 +201,16 @@ export class Getter extends Component {
   }
 
   render() {
+    let containerTip;
+    if (!!!this.props.ijeOnly) {
+      if (!!this.props.allowIje) {
+        containerTip = 'The contents can be formatted as FHIR XML, FHIR JSON, or IJE Mortality.'
+      } else {
+        containerTip = 'The contents can be formatted as FHIR XML or FHIR JSON.'
+      }
+    } else {
+      containerTip = 'The contents must be formatted as an IJE Mortality record.'
+    }
     return (
       <React.Fragment>
         <Form className="p-t-10">
@@ -248,13 +260,7 @@ export class Getter extends Component {
             </Dimmer>
             <Container>
               <Form>
-                {!!!this.props.ijeOnly && !!this.props.allowIje && (
-                  <h4>Paste the record contents below. The contents can be formatted as FHIR XML, FHIR JSON, or IJE Mortality.</h4>
-                )}
-                {!!!this.props.ijeOnly && !!!this.props.allowIje && (
-                  <h4>Paste the record contents below. The contents can be formatted as FHIR XML or FHIR JSON.</h4>
-                )}
-                {!!this.props.ijeOnly && <h4>Paste the IJE Mortality record below.</h4>}
+                <h4>Paste the {!!this.props.messageValidation ? 'message' : 'record'} contents below. {containerTip}</h4>
                 <AceEditor
                   mode="text"
                   theme="chrome"
@@ -287,9 +293,7 @@ export class Getter extends Component {
             <Container>
               <Button as="label" fluid size="big" htmlFor="upload-btn" icon labelPosition="left" loading={this.state.loading} primary>
                 <Icon name="file" />
-                {!!!this.props.ijeOnly && !!this.props.allowIje && 'Select the FHIR XML, FHIR JSON, or IJE Mortality record file you wish to upload.'}
-                {!!!this.props.ijeOnly && !!!this.props.allowIje && 'Select the FHIR XML or FHIR JSON record file you wish to upload.'}
-                {!!this.props.ijeOnly && 'Select the IJE Mortality record file you wish to upload.'}
+                Select the {this.props.messageValidation ? 'message' : 'record'} file you wish to upload. {containerTip}
               </Button>
               <input hidden id="upload-btn" type="file" onChange={this.onChangeFile} />
             </Container>
@@ -302,8 +306,8 @@ export class Getter extends Component {
                 <Icon name="sync" loading={this.state.checking} circular />
                 <span>{this.state.endpoint}</span>
                 <Header.Subheader className="p-t-10">
-                  POST your record to the endpoint shown above, with the message body being the string representation of your record. Canary will update this
-                  page when it detects it has received the record.
+                  POST your {this.props.messageValidation ? 'message' : 'record'} to the endpoint shown above, with the message body being the string representation of your record.
+                  Canary will update this page when it detects it has received the record.
                 </Header.Subheader>
               </Header>
             </Container>

--- a/canary/ClientApp/src/components/misc/Record.js
+++ b/canary/ClientApp/src/components/misc/Record.js
@@ -209,7 +209,10 @@ export class Record extends Component {
               <div className="inherit-width">
                 <Message icon size="large" positive>
                   <Icon name="check circle" />
-                  <Message.Content>No issues were found!</Message.Content>
+                  {!!this.props.messageValidation && (
+                    <Message.Content>Valid {this.props.messageType} message found!</Message.Content>
+                  )}
+                  {!!!this.props.messageValidation && (<Message.Content>No issues were found!</Message.Content>)}
                 </Message>
               </div>
             </Transition>

--- a/canary/ClientApp/src/components/tools/FHIRMessageValidator.js
+++ b/canary/ClientApp/src/components/tools/FHIRMessageValidator.js
@@ -1,0 +1,74 @@
+import React, { Component } from 'react';
+import { Record } from '../misc/Record';
+import { Getter } from '../misc/Getter';
+import { Grid, Breadcrumb } from 'semantic-ui-react';
+import { Link } from 'react-router-dom';
+
+export class FHIRMessageValidator extends Component {
+  displayName = FHIRMessageValidator.name;
+
+  constructor(props) {
+    super(props);
+    this.state = { ...this.props, messageType: null, issues: null };
+    this.updateRecord = this.updateRecord.bind(this);
+  }
+
+  updateRecord(message, issues) {
+    let messageType;
+    switch (message && message.messageType) {
+      case "http://nchs.cdc.gov/vrdr_submission":
+        messageType = "Death Record Submission"
+        break;
+      case "http://nchs.cdc.gov/vrdr_submission_update":
+        messageType = "Death Record Update"
+        break;
+      case "http://nchs.cdc.gov/vrdr_acknowledgement":
+        messageType = "Death Record Acknowledgement"
+        break;
+      case "http://nchs.cdc.gov/vrdr_submission_void":
+        messageType = "Death Record Void"
+        break;
+      case "http://nchs.cdc.gov/vrdr_coding":
+        messageType = "Coding"
+        break;
+      case "http://nchs.cdc.gov/vrdr_coding_update":
+        messageType = "Coding Update"
+        break;
+      case "http://nchs.cdc.gov/vrdr_extraction_error":
+        messageType = "Extraction Error"
+        break;
+      default:
+        messageType = "Unknown"
+        break;
+    }
+
+    this.setState({ record: message, messageType: messageType, issues: issues });
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <Grid>
+          <Grid.Row>
+            <Breadcrumb>
+              <Breadcrumb.Section as={Link} to="/">
+                Dashboard
+              </Breadcrumb.Section>
+              <Breadcrumb.Divider icon="right chevron" />
+              <Breadcrumb.Section>Validate FHIR VRDR Messages</Breadcrumb.Section>
+            </Breadcrumb>
+          </Grid.Row>
+          <Grid.Row>
+            <Getter updateRecord={this.updateRecord} strict messageValidation={true} allowIje={false} />
+          </Grid.Row>
+          <div className="p-b-15" />
+          {!!this.state.issues && (
+            <Grid.Row>
+              <Record record={null} issues={this.state.issues} messageType={this.state.messageType} messageValidation={true} showIssues showSuccess />
+            </Grid.Row>
+          )}
+        </Grid>
+      </React.Fragment>
+    );
+  }
+}

--- a/canary/Controllers/RecordsController.cs
+++ b/canary/Controllers/RecordsController.cs
@@ -141,6 +141,26 @@ namespace canary.Controllers
         }
 
         /// <summary>
+        /// Creates a new message using the contents provided. Returns the message and any validation issues.
+        /// POST /api/records/message/new
+        /// </summary>
+        [HttpPost("Records/Message/New")]
+        public async Task<(BaseMessage message, List<Dictionary<string, string>> issues)> NewMessagePost()
+        {
+            string input = await new StreamReader(Request.Body, Encoding.UTF8).ReadToEndAsync();
+            List<Dictionary<string, string>> entries = new List<Dictionary<string, string>>();
+
+            try {
+                return (message: BaseMessage.Parse(input, false), issues: entries);
+            }
+            catch (Exception e)
+            {
+
+                return (message: null, issues: Record.DecorateErrors(e));
+            }
+        }
+
+        /// <summary>
         /// Creates a new death record using the "description" contents provided. Returns the record.
         /// POST /api/records/description/new
         /// </summary>

--- a/canary/Models/Record.cs
+++ b/canary/Models/Record.cs
@@ -189,23 +189,7 @@ namespace canary.Models
             }
             catch (Exception e)
             {
-                if (e.Message != null && e.Message.Contains(";"))
-                {
-                    foreach (string er in e.Message.Split(";"))
-                    {
-                        Dictionary<string, string> entry = new Dictionary<string, string>();
-                        entry.Add("message", er.Replace("Parser:", "").Trim());
-                        entry.Add("severity", "error");
-                        entries.Add(entry);
-                    }
-                }
-                else if (e.Message != null)
-                {
-                    Dictionary<string, string> entry = new Dictionary<string, string>();
-                    entry.Add("message", e.Message.Replace("Parser:", "").Trim());
-                    entry.Add("severity", "error");
-                    entries.Add(entry);
-                }
+                entries = DecorateErrors(e);
             }
             return (record: newRecord, issues: entries);
         }
@@ -221,25 +205,32 @@ namespace canary.Models
             }
             catch (Exception e)
             {
-                if (e.Message != null && e.Message.Contains(";"))
-                {
-                    foreach (string er in e.Message.Split(";"))
-                    {
-                        Dictionary<string, string> entry = new Dictionary<string, string>();
-                        entry.Add("message", er.Replace("Parser:", "").Trim());
-                        entry.Add("severity", "error");
-                        entries.Add(entry);
-                    }
-                }
-                else if (e.Message != null)
+                entries = DecorateErrors(e);
+            }
+            return (record: newCauses, issues: entries);
+        }
+
+        public static List<Dictionary<string, string>> DecorateErrors(Exception e) {
+            List<Dictionary<string, string>> entries = new List<Dictionary<string, string>>();
+
+            if (e.Message != null && e.Message.Contains(";"))
+            {
+                foreach (string er in e.Message.Split(";"))
                 {
                     Dictionary<string, string> entry = new Dictionary<string, string>();
-                    entry.Add("message", e.Message.Replace("Parser:", "").Trim());
+                    entry.Add("message", er.Replace("Parser:", "").Trim());
                     entry.Add("severity", "error");
                     entries.Add(entry);
                 }
             }
-            return (record: newCauses, issues: entries);
+            else if (e.Message != null)
+            {
+                Dictionary<string, string> entry = new Dictionary<string, string>();
+                entry.Add("message", e.Message.Replace("Parser:", "").Trim());
+                entry.Add("severity", "error");
+                entries.Add(entry);
+            }
+            return entries;
         }
 
         /// <summary>Populate this record with synthetic data.</summary>

--- a/canary/Models/Record.cs
+++ b/canary/Models/Record.cs
@@ -213,7 +213,7 @@ namespace canary.Models
         public static List<Dictionary<string, string>> DecorateErrors(Exception e) {
             List<Dictionary<string, string>> entries = new List<Dictionary<string, string>>();
 
-            if (e.Message != null && e.Message.Contains(";"))
+            if (e.Message != null)
             {
                 foreach (string er in e.Message.Split(";"))
                 {
@@ -222,13 +222,6 @@ namespace canary.Models
                     entry.Add("severity", "error");
                     entries.Add(entry);
                 }
-            }
-            else if (e.Message != null)
-            {
-                Dictionary<string, string> entry = new Dictionary<string, string>();
-                entry.Add("message", e.Message.Replace("Parser:", "").Trim());
-                entry.Add("severity", "error");
-                entries.Add(entry);
             }
             return entries;
         }

--- a/canary/Startup.cs
+++ b/canary/Startup.cs
@@ -6,7 +6,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using canary.Models;
 
 namespace canary
 {

--- a/canary/canary.csproj
+++ b/canary/canary.csproj
@@ -14,8 +14,11 @@
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.3" />
-    <PackageReference Include="VRDR" Version="3.1.0-preview3" />
-    <!-- <ProjectReference Include="..\vrdr-dotnet\VRDR\DeathRecord.csproj" /> -->
+    <PackageReference Include="VRDR" Version="3.1.0-preview9" />
+    <PackageReference Include="VRDR.Messaging" Version="3.1.0-preview9" />
+
+    <!-- <ProjectReference Include="..\..\vrdr-dotnet\VRDR\DeathRecord.csproj" /> -->
+    <!-- <ProjectReference Include="..\..\vrdr-dotnet\VRDR.Messaging\VRDRMessaging.csproj" /> -->
     <PackageReference Include="Bogus" Version="29.0.1" />
   </ItemGroup>
 

--- a/canary/canary.csproj
+++ b/canary/canary.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.3" />
-    <PackageReference Include="VRDR" Version="3.1.0-preview9" />
     <PackageReference Include="VRDR.Messaging" Version="3.1.0-preview9" />
 
     <!-- <ProjectReference Include="..\..\vrdr-dotnet\VRDR\DeathRecord.csproj" /> -->


### PR DESCRIPTION
This currently requires usage of the local `business_identifiers` branch on vrdr-dotnet, specifically https://github.com/nightingaleproject/vrdr-dotnet/pull/110/commits/31bbb567399a5ee0698564d2450fc0a46ff0387d which adds a parse message that takes a string instead of a StreamReader.