### PR TITLE
Always show the base exception instead of the outer exception when an error is raised

### DIFF
--- a/canary/Models/Record.cs
+++ b/canary/Models/Record.cs
@@ -197,10 +197,10 @@ namespace canary.Models
         public static List<Dictionary<string, string>> DecorateErrors(Exception e) {
             List<Dictionary<string, string>> entries = new List<Dictionary<string, string>>();
 
-            if (e.Message != null)
-            {
-                Exception baseException = e.GetBaseException();
+            Exception baseException = e.GetBaseException();
 
+            if (baseException.Message != null)
+            {
                 foreach (string er in baseException.Message.Split(";"))
                 {
                     Dictionary<string, string> entry = new Dictionary<string, string>();

--- a/canary/Models/Record.cs
+++ b/canary/Models/Record.cs
@@ -199,10 +199,19 @@ namespace canary.Models
 
             if (e.Message != null)
             {
-                foreach (string er in e.Message.Split(";"))
+                Exception baseException = e.GetBaseException();
+
+                foreach (string er in baseException.Message.Split(";"))
                 {
                     Dictionary<string, string> entry = new Dictionary<string, string>();
-                    entry.Add("message", er.Replace("Parser:", "").Trim());
+                    // targetSite contains the information required to show the function class and function that
+                    // the error occurred in
+                    var targetSite = baseException.TargetSite;
+                    string erString = er.Trim();
+                    // Ensure the original error string always ends in a period.
+                    if (!erString.EndsWith('.')) erString += '.';
+                    string errorWithLocation = $"{erString} Error occurred at {targetSite.ReflectedType} in function {targetSite.Name}.";
+                    entry.Add("message", errorWithLocation.Replace("Parser:", "").Trim());
                     entry.Add("severity", "error");
                     entries.Add(entry);
                 }


### PR DESCRIPTION
There are some cases where the error gets wrapped with another exception (For example if an object is being cast to a different type and raises an error in the process). This change will now always show the base error.

Also, add on additional information to the error message to help users identify what is causing the validation error.

- [x] Validate to see if the full error message actually displays properly when compiled for production (there's a chance the symbols required to show the function name will be missing in the compiled version).

<img width="1177" alt="Screen Shot 2020-06-24 at 2 09 18 PM" src="https://user-images.githubusercontent.com/2308869/85609681-52a75f80-b624-11ea-9962-bebcf420aa8d.png">
<img width="1174" alt="Screen Shot 2020-06-24 at 2 09 10 PM" src="https://user-images.githubusercontent.com/2308869/85609682-533ff600-b624-11ea-8207-a31a2a2ace65.png">
