### PR TITLE
 Validate that a record can be serialized by Canary before passing the record to the controller

### DIFF
--- a/canary/ClientApp/src/components/Navigation.js
+++ b/canary/ClientApp/src/components/Navigation.js
@@ -34,7 +34,7 @@ export class Navigation extends Component {
             <Dropdown item text="Message Testing" direction="left">
               <Dropdown.Menu>
                 <Dropdown.Item icon="cloud upload" text="Producing FHIR Messages" as={Link} to="/test-fhir-message-producing" />
-                <Dropdown.Item icon={<i class="icon"><FontAwesomeIcon icon={faMailBulk} fixedWidth /></i>} text="Connectathon FHIR Messages (Producing)" as={Link} to="/test-connectathon-dash/message" />
+                <Dropdown.Item icon={<i className="icon"><FontAwesomeIcon icon={faMailBulk} fixedWidth /></i>} text="Connectathon FHIR Messages (Producing)" as={Link} to="/test-connectathon-dash/message" />
               </Dropdown.Menu>
             </Dropdown>
             <Dropdown item text="Record Tools" direction="left">

--- a/canary/Models/Record.cs
+++ b/canary/Models/Record.cs
@@ -184,7 +184,12 @@ namespace canary.Models
             List<Dictionary<string, string>> entries = new List<Dictionary<string, string>>();
             try
             {
-                newRecord = new Record(new DeathRecord(record, permissive));
+                Record recordToSerialize = new Record(new DeathRecord(record, permissive));
+                // If the object fails to serialize then it will not be possible for canary to return it to the user
+                // (since canary has to serialize it to JSON in order to do so). This is why serialization is tested
+                // here and if it passes then the record is considered "safe" to return.
+                JsonConvert.SerializeObject(recordToSerialize);
+                newRecord = recordToSerialize;
                 return (record: newRecord, issues: entries);
             }
             catch (Exception e)


### PR DESCRIPTION
When an object is returned from a controller, it is automatically serialized. If serialization is not tested and verified ahead of time, then this will throw an exception outside of the scope of our code. By validating ahead of time and returning a nicer error to the user this behavior can be avoided.