### PR TITLE
Update to the latest patch of the dotnet SDK

### DIFF
--- a/.github/workflows/build-executable.yml
+++ b/.github/workflows/build-executable.yml
@@ -12,8 +12,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.408
     - name: Setup Database
       run: |
         dotnet tool install --global dotnet-ef

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,8 +17,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.408
     - name: Install dependencies
       run: dotnet restore
     - name: Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.408 AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1.409 AS build-env
 WORKDIR /app
 RUN apt-get update -qq && apt-get install -y nodejs
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.408"
+    "version": "3.1.409",
+    "rollForward": "patch"
   }
 }


### PR DESCRIPTION
Remove hardcoding of sdk.version in github workflows, by default it reads the global.json