### PR TITLE
Rename Validators to Syntax Checkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,23 @@ Canary is an open source testing framework that supports development of systems 
 If you are upgrading from 2.x.x to 3.x.x, please note that there are differences between FHIR STU3 and R4 that impact the structure of the VRDR Death Record. [This commit illustrates the differences between FHIR STU3 and FHIR R4 VRDR Death Records](https://github.com/nightingaleproject/vrdr-dotnet/commit/2b4c2026fdab80e7233f3a7d7ed6e17d5d63f38e). Death Record data may need similar updates from STU3 to R4 when updating to Canary Version 3.
 
 Canary can test a data providers ability to:
-- Produce FHIR Death Records
-- Consume FHIR Death Records
+- Produce FHIR VRDR Records
+- Consume FHIR VRDR Records
 - Roundtrip: Convert between FHIR (Consuming) and the IJE Mortality format (Producing)
 - Roundtrip: Convert between the IJE Mortality format (Consuming) and FHIR (Producing)
-- Produce predefined FHIR Death Records as tested at Connectathons
-- Produce FHIR Messages
-- Produce predefined FHIR Messages as tested at Connectathons
+- Produce predefined FHIR VRDR Records as tested at Connectathons
+- Produce FHIR VRDR Messages
+- Produce predefined FHIR VRDR Messages as tested at Connectathons
 
 Canary also includes the following utilities:
-- Generate Synthetic Death Records
-- Validate FHIR Death Records
-- Death Record Format Converter
-- FHIR Death Record Inspector
-- FHIR Death Record Creator
+- Generate Synthetic VRDR Records
+- FHIR VRDR Record Syntax Checker
+- VRDR Record Format Converter
+- FHIR VRDR Record Inspector
+- FHIR VRDR Record Creator
 - IJE Mortality Record Inspector
-- Validate FHIR Messages
-- Create FHIR Messages
+- FHIR VRDR Message Syntax Checker
+- Create FHIR VRDR Messages
 
 ### Background
 

--- a/canary/ClientApp/src/App.js
+++ b/canary/ClientApp/src/App.js
@@ -13,8 +13,8 @@ import { RecentTests } from './components/tests/RecentTests';
 import { FHIRCreator } from './components/tools/FHIRCreator';
 import { FHIRInspector } from './components/tools/FHIRInspector';
 import { FHIRMessageCreator } from './components/tools/FHIRMessageCreator';
-import { FHIRMessageValidator } from './components/tools/FHIRMessageValidator';
-import { FHIRValidator } from './components/tools/FHIRValidator';
+import { FHIRMessageSyntaxChecker } from './components/tools/FHIRMessageSyntaxChecker';
+import { FHIRSyntaxChecker } from './components/tools/FHIRSyntaxChecker';
 import { IJEInspector } from './components/tools/IJEInspector';
 import { MessageConnectathonProducing } from './components/tests/MessageConnectathonProducing';
 import { RecordConverter } from './components/tools/RecordConverter';
@@ -40,8 +40,8 @@ export default class App extends Component {
           <Route path="/test-connectathon-messaging/:id" component={MessageConnectathonProducing} />
           <Route path="/tool-fhir-inspector" component={FHIRInspector} />
           <Route path="/tool-fhir-creator" component={FHIRCreator} />
-          <Route path="/tool-fhir-validator" component={FHIRValidator} />
-          <Route path="/tool-fhir-message-validator" component={FHIRMessageValidator} />
+          <Route path="/tool-fhir-syntax-checker" component={FHIRSyntaxChecker} />
+          <Route path="/tool-fhir-message-syntax-checker" component={FHIRMessageSyntaxChecker} />
           <Route path="/tool-ije-inspector" component={IJEInspector} />
           <Route path="/tool-record-converter" component={RecordConverter} />
           <Route path="/tool-record-generator" component={RecordGenerator} />

--- a/canary/ClientApp/src/components/Navigation.js
+++ b/canary/ClientApp/src/components/Navigation.js
@@ -24,33 +24,33 @@ export class Navigation extends Component {
             <Menu.Item name="dashboard" as={Link} to="/" icon="dashboard" />
             <Dropdown item text="Record Testing" direction="left">
               <Dropdown.Menu>
-                <Dropdown.Item icon="upload" text="Producing FHIR Death Records" as={Link} to="/test-fhir-producing" />
-                <Dropdown.Item icon="download" text="Consuming FHIR Death Records" as={Link} to="/test-fhir-consuming" />
-                <Dropdown.Item icon="sync" text="Death Record Roundtrip (Consuming)" as={Link} to="/test-edrs-roundtrip-consuming" />
-                <Dropdown.Item icon="sync" text="Death Record Roundtrip (Producing)" as={Link} to="/test-edrs-roundtrip-producing" />
-                <Dropdown.Item icon="tasks" text="Connectathon FHIR Death Records (Producing)" as={Link} to="/test-connectathon-dash/records" />
+                <Dropdown.Item icon="upload" text="Producing FHIR VRDR Records" as={Link} to="/test-fhir-producing" />
+                <Dropdown.Item icon="download" text="Consuming FHIR VRDR Records" as={Link} to="/test-fhir-consuming" />
+                <Dropdown.Item icon="sync" text="VRDR Record Roundtrip (Consuming)" as={Link} to="/test-edrs-roundtrip-consuming" />
+                <Dropdown.Item icon="sync" text="VRDR Record Roundtrip (Producing)" as={Link} to="/test-edrs-roundtrip-producing" />
+                <Dropdown.Item icon="tasks" text="Connectathon FHIR VRDR Records (Producing)" as={Link} to="/test-connectathon-dash/records" />
               </Dropdown.Menu>
             </Dropdown>
             <Dropdown item text="Message Testing" direction="left">
               <Dropdown.Menu>
-                <Dropdown.Item icon="cloud upload" text="Producing FHIR Messages" as={Link} to="/test-fhir-message-producing" />
-                <Dropdown.Item icon={<i className="icon"><FontAwesomeIcon icon={faMailBulk} fixedWidth /></i>} text="Connectathon FHIR Messages (Producing)" as={Link} to="/test-connectathon-dash/message" />
+                <Dropdown.Item icon="cloud upload" text="Producing FHIR VRDR Messages" as={Link} to="/test-fhir-message-producing" />
+                <Dropdown.Item icon={<i className="icon"><FontAwesomeIcon icon={faMailBulk} fixedWidth /></i>} text="Connectathon FHIR VRDR Messages (Producing)" as={Link} to="/test-connectathon-dash/message" />
               </Dropdown.Menu>
             </Dropdown>
             <Dropdown item text="Record Tools" direction="left">
               <Dropdown.Menu>
-                <Dropdown.Item icon="clipboard list" text="Generate Synthetic Death Records" as={Link} to="/tool-record-generator" />
-                <Dropdown.Item icon="clipboard check" text="Validate FHIR Records" as={Link} to="/tool-fhir-syntax-checker" />
-                <Dropdown.Item icon="random" text="Death Record Format Converter" as={Link} to="/tool-record-converter" />
-                <Dropdown.Item icon="find" text="FHIR Death Record Inspector" as={Link} to="/tool-fhir-inspector" />
-                <Dropdown.Item icon="magic" text="FHIR Death Record Creator" as={Link} to="/tool-fhir-creator" />
+                <Dropdown.Item icon="clipboard list" text="Generate Synthetic VRDR Records" as={Link} to="/tool-record-generator" />
+                <Dropdown.Item icon="clipboard check" text="FHIR VRDR Record Syntax Checker" as={Link} to="/tool-fhir-syntax-checker" />
+                <Dropdown.Item icon="random" text="VRDR Record Format Converter" as={Link} to="/tool-record-converter" />
+                <Dropdown.Item icon="find" text="FHIR VRDR Record Inspector" as={Link} to="/tool-fhir-inspector" />
+                <Dropdown.Item icon="magic" text="FHIR VRDR Record Creator" as={Link} to="/tool-fhir-creator" />
                 <Dropdown.Item icon="search" text="IJE Mortality Record Inspector" as={Link} to="/tool-ije-inspector" />
               </Dropdown.Menu>
             </Dropdown>
             <Dropdown item text="Message Tools" direction="left">
               <Dropdown.Menu>
-                <Dropdown.Item icon="envelope" text="Validate FHIR Messages" as={Link} to="/tool-fhir-message-syntax-checker" />
-                <Dropdown.Item icon="cloud download" text="Creating FHIR Messages" as={Link} to="/test-fhir-message-creation" />
+                <Dropdown.Item icon="envelope" text="FHIR VRDR Message Syntax Checker" as={Link} to="/tool-fhir-message-syntax-checker" />
+                <Dropdown.Item icon="cloud download" text="Creating FHIR VRDR Messages" as={Link} to="/test-fhir-message-creation" />
               </Dropdown.Menu>
             </Dropdown>
           </Menu.Menu>

--- a/canary/ClientApp/src/components/Navigation.js
+++ b/canary/ClientApp/src/components/Navigation.js
@@ -40,7 +40,7 @@ export class Navigation extends Component {
             <Dropdown item text="Record Tools" direction="left">
               <Dropdown.Menu>
                 <Dropdown.Item icon="clipboard list" text="Generate Synthetic Death Records" as={Link} to="/tool-record-generator" />
-                <Dropdown.Item icon="clipboard check" text="Validate FHIR Records" as={Link} to="/tool-fhir-validator" />
+                <Dropdown.Item icon="clipboard check" text="Validate FHIR Records" as={Link} to="/tool-fhir-syntax-checker" />
                 <Dropdown.Item icon="random" text="Death Record Format Converter" as={Link} to="/tool-record-converter" />
                 <Dropdown.Item icon="find" text="FHIR Death Record Inspector" as={Link} to="/tool-fhir-inspector" />
                 <Dropdown.Item icon="magic" text="FHIR Death Record Creator" as={Link} to="/tool-fhir-creator" />
@@ -49,7 +49,7 @@ export class Navigation extends Component {
             </Dropdown>
             <Dropdown item text="Message Tools" direction="left">
               <Dropdown.Menu>
-                <Dropdown.Item icon="envelope" text="Validate FHIR Messages" as={Link} to="/tool-fhir-message-validator" />
+                <Dropdown.Item icon="envelope" text="Validate FHIR Messages" as={Link} to="/tool-fhir-message-syntax-checker" />
                 <Dropdown.Item icon="cloud download" text="Creating FHIR Messages" as={Link} to="/test-fhir-message-creation" />
               </Dropdown.Menu>
             </Dropdown>

--- a/canary/ClientApp/src/components/dashboard/Dashboard.js
+++ b/canary/ClientApp/src/components/dashboard/Dashboard.js
@@ -44,31 +44,31 @@ export class Dashboard extends Component {
               <Item.Group className="m-h-30">
                 <DashboardItem
                   icon="upload"
-                  title="Producing FHIR Death Records"
-                  description="Test a data provider system's ability to produce a valid FHIR Death Record document."
+                  title="Producing FHIR VRDR Records"
+                  description="Test a data provider system's ability to produce a valid FHIR VRDR Record document."
                   route="test-fhir-producing"
                 />
                 <DashboardItem
                   icon="download"
-                  title="Consuming FHIR Death Records"
-                  description="Test a data provider system's ability to consume a valid FHIR Death Record document."
+                  title="Consuming FHIR VRDR Records"
+                  description="Test a data provider system's ability to consume a valid FHIR VRDR Record document."
                   route="test-fhir-consuming"
                 />
                 <DashboardItem
                   icon="sync"
-                  title="Death Record Roundtrip (Consuming)"
+                  title="VRDR Record Roundtrip (Consuming)"
                   description="Test a data provider system's ability to handle converting between internal data structures and external data formats. This test involves consuming FHIR, and then producing equivalent IJE."
                   route="test-edrs-roundtrip-consuming"
                 />
                 <DashboardItem
                   icon="sync"
-                  title="Death Record Roundtrip (Producing)"
+                  title="VRDR Record Roundtrip (Producing)"
                   description="Test a data provider system's ability to handle converting between internal data structures and external data formats. This test involves consuming IJE, and then producing equivalent FHIR."
                   route="test-edrs-roundtrip-producing"
                 />
                 <DashboardItem
                   icon="tasks"
-                  title="Connectathon FHIR Death Records (Producing)"
+                  title="Connectathon FHIR VRDR Records (Producing)"
                   description="Test a data provider system's ability to produce pre-defined records as tested at Connectathons."
                   route="test-connectathon-dash/records"
                 />
@@ -82,14 +82,14 @@ export class Dashboard extends Component {
               <Item.Group className="m-h-30">
                 <DashboardItem
                   icon="cloud upload"
-                  title="Producing FHIR Messages"
-                  description="Test a data provider system's ability to produce a valid FHIR Message for a generated FHIR Death Record document."
+                  title="Producing FHIR VRDR Messages"
+                  description="Test a data provider system's ability to produce a valid FHIR Message for a generated FHIR VRDR Record document."
                   route="test-fhir-message-producing"
                 />
                 <DashboardItem
                   faIcon={faMailBulk}
-                  title="Connectathon FHIR Messages (Producing)"
-                  description="Test a data provider system's ability to produce pre-defined FHIR Messages as tested at Connectathons."
+                  title="Connectathon FHIR VRDR Messages (Producing)"
+                  description="Test a data provider system's ability to produce pre-defined FHIR VRDR Messages as tested at Connectathons."
                   route="test-connectathon-dash/message"
                 />
               </Item.Group>
@@ -102,8 +102,8 @@ export class Dashboard extends Component {
               <Item.Group className="m-h-30">
                 <DashboardItem
                   icon="clipboard list"
-                  title="Generate Synthetic Death Records"
-                  description="Generate synthetic death records in FHIR (XML or JSON) and IJE Mortality format. These generated records can be downloaded locally, copied to the clipboard, or POSTed to an endpoint."
+                  title="Generate Synthetic VRDR Records"
+                  description="Generate synthetic VRDR records in FHIR (XML or JSON) and IJE Mortality format. These generated records can be downloaded locally, copied to the clipboard, or POSTed to an endpoint."
                   route="tool-record-generator"
                 />
                 <DashboardItem
@@ -114,19 +114,19 @@ export class Dashboard extends Component {
                 />
                 <DashboardItem
                   icon="random"
-                  title="Death Record Format Converter"
-                  description="Convert between various Death Record formats, including FHIR and IJE Mortality."
+                  title="VRDR Record Format Converter"
+                  description="Convert between various VRDR Record formats, including FHIR and IJE Mortality."
                   route="tool-record-converter"
                 />
                 <DashboardItem
                   icon="find"
-                  title="FHIR Death Record Inspector"
-                  description="Inspect a FHIR Death Record and show details about the record and what it contains."
+                  title="FHIR VRDR Record Inspector"
+                  description="Inspect a FHIR VRDR Record and show details about the record and what it contains."
                   route="tool-fhir-inspector"
                 />
                 <DashboardItem
                   icon="magic"
-                  title="FHIR Death Record Creator"
+                  title="FHIR VRDR Record Creator"
                   description="Create a new record from scratch by filling out a web form, and generate FHIR from it."
                   route="tool-fhir-creator"
                 />
@@ -152,8 +152,8 @@ export class Dashboard extends Component {
                 />
                 <DashboardItem
                   icon="cloud download"
-                  title="Creating FHIR Messages"
-                  description="Create a valid FHIR Message for a user provided FHIR Death Record document."
+                  title="Creating FHIR VRDR Messages"
+                  description="Create a valid FHIR Message for a user provided FHIR VRDR Record document."
                   route="test-fhir-message-creation"
                 />
               </Item.Group>

--- a/canary/ClientApp/src/components/dashboard/Dashboard.js
+++ b/canary/ClientApp/src/components/dashboard/Dashboard.js
@@ -108,9 +108,9 @@ export class Dashboard extends Component {
                 />
                 <DashboardItem
                   icon="clipboard check"
-                  title="Validate FHIR VRDR Records"
+                  title="FHIR VRDR Record Syntax Checker"
                   description="Check a given FHIR VRDR Record for syntax/structural issues."
-                  route="tool-fhir-validator"
+                  route="tool-fhir-syntax-checker"
                 />
                 <DashboardItem
                   icon="random"
@@ -146,9 +146,9 @@ export class Dashboard extends Component {
               <Item.Group className="m-h-30">
                 <DashboardItem
                   icon="envelope"
-                  title="Validate FHIR VRDR Messages"
+                  title="FHIR VRDR Message Syntax Checker"
                   description="Check a given FHIR VRDR Message for syntax/structural issues."
-                  route="tool-fhir-message-validator"
+                  route="tool-fhir-message-syntax-checker"
                 />
                 <DashboardItem
                   icon="cloud download"

--- a/canary/ClientApp/src/components/tests/Connectathon.js
+++ b/canary/ClientApp/src/components/tests/Connectathon.js
@@ -115,7 +115,7 @@ export class Connectathon extends Component {
               Dashboard
             </Breadcrumb.Section>
             <Breadcrumb.Divider icon="right chevron" />
-            <Breadcrumb.Section>Connectathon FHIR Death Records</Breadcrumb.Section>
+            <Breadcrumb.Section>Connectathon FHIR VRDR Records</Breadcrumb.Section>
           </Breadcrumb>
         </Grid.Row>
         {!!this.state.test && this.state.test.completedBool && (

--- a/canary/ClientApp/src/components/tests/EDRSRoundtripConsuming.js
+++ b/canary/ClientApp/src/components/tests/EDRSRoundtripConsuming.js
@@ -99,7 +99,7 @@ export class EDRSRoundtripConsuming extends Component {
                 Dashboard
               </Breadcrumb.Section>
               <Breadcrumb.Divider icon="right chevron" />
-              <Breadcrumb.Section>Death Record Roundtrip (Consuming)</Breadcrumb.Section>
+              <Breadcrumb.Section>VRDR Record Roundtrip (Consuming)</Breadcrumb.Section>
             </Breadcrumb>
           </Grid.Row>
           {!!this.state.test && this.state.test.completedBool && (

--- a/canary/ClientApp/src/components/tests/EDRSRoundtripProducing.js
+++ b/canary/ClientApp/src/components/tests/EDRSRoundtripProducing.js
@@ -99,7 +99,7 @@ export class EDRSRoundtripProducing extends Component {
                 Dashboard
               </Breadcrumb.Section>
               <Breadcrumb.Divider icon="right chevron" />
-              <Breadcrumb.Section>Death Record Roundtrip (Producing)</Breadcrumb.Section>
+              <Breadcrumb.Section>VRDR Record Roundtrip (Producing)</Breadcrumb.Section>
             </Breadcrumb>
           </Grid.Row>
           {!!this.state.test && this.state.test.completedBool && (

--- a/canary/ClientApp/src/components/tests/FHIRConsuming.js
+++ b/canary/ClientApp/src/components/tests/FHIRConsuming.js
@@ -118,7 +118,7 @@ export class FHIRConsuming extends Component {
                 Dashboard
               </Breadcrumb.Section>
               <Breadcrumb.Divider icon="right chevron" />
-              <Breadcrumb.Section>Consuming FHIR Death Records</Breadcrumb.Section>
+              <Breadcrumb.Section>Consuming FHIR VRDR Records</Breadcrumb.Section>
             </Breadcrumb>
           </Grid.Row>
           {!!this.state.test && this.state.test.completedBool && (

--- a/canary/ClientApp/src/components/tests/FHIRProducing.js
+++ b/canary/ClientApp/src/components/tests/FHIRProducing.js
@@ -105,7 +105,7 @@ export class FHIRProducing extends Component {
                 Dashboard
               </Breadcrumb.Section>
               <Breadcrumb.Divider icon="right chevron" />
-              <Breadcrumb.Section>Producing FHIR Death Records</Breadcrumb.Section>
+              <Breadcrumb.Section>Producing FHIR VRDR Records</Breadcrumb.Section>
             </Breadcrumb>
           </Grid.Row>
           {!!this.state.test && this.state.test.completedBool && (

--- a/canary/ClientApp/src/components/tools/FHIRCreator.js
+++ b/canary/ClientApp/src/components/tools/FHIRCreator.js
@@ -76,7 +76,7 @@ export class FHIRCreator extends Component {
               Dashboard
             </Breadcrumb.Section>
             <Breadcrumb.Divider icon="right chevron" />
-            <Breadcrumb.Section>FHIR Death Record Creator</Breadcrumb.Section>
+            <Breadcrumb.Section>FHIR VRDR Record Creator</Breadcrumb.Section>
           </Breadcrumb>
         </Grid.Row>
         {!!this.state.fhirInfo && (

--- a/canary/ClientApp/src/components/tools/FHIRInspector.js
+++ b/canary/ClientApp/src/components/tools/FHIRInspector.js
@@ -36,7 +36,7 @@ export class FHIRInspector extends Component {
                 Dashboard
               </Breadcrumb.Section>
               <Breadcrumb.Divider icon="right chevron" />
-              <Breadcrumb.Section>FHIR Death Record Inspector</Breadcrumb.Section>
+              <Breadcrumb.Section>FHIR VRDR Record Inspector</Breadcrumb.Section>
             </Breadcrumb>
           </Grid.Row>
           <Grid.Row>

--- a/canary/ClientApp/src/components/tools/FHIRMessageSyntaxChecker.js
+++ b/canary/ClientApp/src/components/tools/FHIRMessageSyntaxChecker.js
@@ -5,8 +5,8 @@ import { messageTypes } from '../../data';
 import { Getter } from '../misc/Getter';
 import { Record } from '../misc/Record';
 
-export class FHIRMessageValidator extends Component {
-  displayName = FHIRMessageValidator.name;
+export class FHIRMessageSyntaxChecker extends Component {
+  displayName = FHIRMessageSyntaxChecker.name;
 
   constructor(props) {
     super(props);
@@ -33,7 +33,7 @@ export class FHIRMessageValidator extends Component {
                 Dashboard
               </Breadcrumb.Section>
               <Breadcrumb.Divider icon="right chevron" />
-              <Breadcrumb.Section>Validate FHIR VRDR Messages</Breadcrumb.Section>
+              <Breadcrumb.Section>FHIR VRDR Message Syntax Checker</Breadcrumb.Section>
             </Breadcrumb>
           </Grid.Row>
           <Grid.Row>

--- a/canary/ClientApp/src/components/tools/FHIRSyntaxChecker.js
+++ b/canary/ClientApp/src/components/tools/FHIRSyntaxChecker.js
@@ -4,8 +4,8 @@ import { Breadcrumb, Grid } from 'semantic-ui-react';
 import { Getter } from '../misc/Getter';
 import { Record } from '../misc/Record';
 
-export class FHIRValidator extends Component {
-  displayName = FHIRValidator.name;
+export class FHIRSyntaxChecker extends Component {
+  displayName = FHIRSyntaxChecker.name;
 
   constructor(props) {
     super(props);
@@ -27,7 +27,7 @@ export class FHIRValidator extends Component {
                 Dashboard
               </Breadcrumb.Section>
               <Breadcrumb.Divider icon="right chevron" />
-              <Breadcrumb.Section>Validate FHIR VRDR Records</Breadcrumb.Section>
+              <Breadcrumb.Section>FHIR VRDR Record Syntax Checker</Breadcrumb.Section>
             </Breadcrumb>
           </Grid.Row>
           <Grid.Row>

--- a/canary/ClientApp/src/components/tools/RecordConverter.js
+++ b/canary/ClientApp/src/components/tools/RecordConverter.js
@@ -29,7 +29,7 @@ export class RecordConverter extends Component {
                 Dashboard
               </Breadcrumb.Section>
               <Breadcrumb.Divider icon="right chevron" />
-              <Breadcrumb.Section>Death Record Format Converter</Breadcrumb.Section>
+              <Breadcrumb.Section>VRDR Record Format Converter</Breadcrumb.Section>
             </Breadcrumb>
           </Grid.Row>
           <Grid.Row>

--- a/canary/ClientApp/src/components/tools/RecordGenerator.js
+++ b/canary/ClientApp/src/components/tools/RecordGenerator.js
@@ -81,7 +81,7 @@ export class RecordGenerator extends Component {
                 Dashboard
               </Breadcrumb.Section>
               <Breadcrumb.Divider icon="right chevron" />
-              <Breadcrumb.Section>Generate Synthetic Death Records</Breadcrumb.Section>
+              <Breadcrumb.Section>Generate Synthetic VRDR Records</Breadcrumb.Section>
             </Breadcrumb>
           </Grid.Row>
           <Grid.Row className="no-padding-b">


### PR DESCRIPTION
This should be less misleading to end users on the true nature of what the 'Validators' actually do.

Fixes https://tracker.codev.mitre.org/browse/NVSS-89