### PR TITLE
Update connectathon certificate numbers to new numbers for 2021 connectathon

### DIFF
--- a/canary/ClientApp/src/components/dashboard/ConnectathonDashboard.js
+++ b/canary/ClientApp/src/components/dashboard/ConnectathonDashboard.js
@@ -26,7 +26,7 @@ export class ConnectathonDashboard extends Component {
               <Divider horizontal>
                 <Header as="h2">
                   <Icon name="clipboard list" />
-                  IHE Connectathon 2020 {this.props.match.params.type} testing
+                  IHE Connectathon 2021 {this.props.match.params.type} testing
                 </Header>
               </Divider>
               <Item.Group className="m-h-30">

--- a/canary/ClientApp/src/data.js
+++ b/canary/ClientApp/src/data.js
@@ -91,9 +91,9 @@ export const connectathonRecordNames = {
 }
 
 export const connectathonRecordCertificateNumbers = {
-  "1": "50",
-  "2": "51",
-  "3": "52",
-  "4": "53",
-  "5": "53"
+  "1": "1",
+  "2": "2",
+  "3": "3",
+  "4": "4",
+  "5": "5"
 }


### PR DESCRIPTION
Update date to 2021 as well.