### PR TITLE
Push to docker on merge to master and release

### DIFF
--- a/.github/workflows/push-to-docker.yml
+++ b/.github/workflows/push-to-docker.yml
@@ -1,0 +1,23 @@
+name: Push to docker on every merge to master and tag as latest
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: mitre/canary:latest

--- a/.github/workflows/release-to-docker.yml
+++ b/.github/workflows/release-to-docker.yml
@@ -1,0 +1,23 @@
+name: Push to docker on every release and tag as release-latest and version
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: mitre/canary:release-latest,mitre/canary:${{ github.event.release.tag_name }}


### PR DESCRIPTION
I am more confident that the push latest tag will work than the releases due to the `${{ github.event.release.tag_name }}` variable. Unfortunately there is no way to test short of just doing a release.