### PR TITLE
Update README link to IG to STU2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Canary EDRS Testing Framework
 
-Canary is an open source testing framework that supports development of systems that perform standards based exchange of mortality data. Canary provides tests and tools to aid developers in implementing the Vital Records Death Reporting (VRDR) FHIR death record format (http://hl7.org/fhir/us/vrdr) Revision 4.
+Canary is an open source testing framework that supports development of systems that perform standards based exchange of mortality data. Canary provides tests and tools to aid developers in implementing the Vital Records Death Reporting (VRDR) FHIR death record format STU2 (http://hl7.org/fhir/us/vrdr/2021Sep/) FHIR Revision 4.
 
 ## Versions
 


### PR DESCRIPTION
Ticket 251, reviewed the canary README for any necessary updates. Only change was to the IG link at the top of the README. Now it points to STU2. 