### PR TITLE
Change examiner contacted to from no to unknown to match test case

### DIFF
--- a/canary/Models/Connectathon.cs
+++ b/canary/Models/Connectathon.cs
@@ -772,7 +772,7 @@ namespace canary.Models
 
             record.COD1A = "Blunt head trauma";
             record.COD1B = "Automobile accident";
-            record.ExaminerContactedBoolean = fullRecord;
+            record.ExaminerContactedBoolean = null; // use null to set to unknown
             if (fullRecord)
             {
                 record.INTERVAL1A = "30 min";


### PR DESCRIPTION
Genesis found an error in the canary Connectathon Messaging Test 5. The connectathon test files have examiner contacted = UNK but the reference file canary uses was setting it to N. Updated the code in canary to set it to unknown instead.