### PR TITLE
Removed obsolete compatibility function.

### DIFF
--- a/canary/Startup.cs
+++ b/canary/Startup.cs
@@ -28,7 +28,7 @@ namespace canary
         {
             services.AddMvc(options =>
                 options.EnableEndpointRouting = false
-            ).SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+            );
 
             // In production, the React files will be served from this directory
             services.AddSpaStaticFiles(configuration =>


### PR DESCRIPTION
This compatibility function has been a no-op since .NET 3.0, is marked as obsolete, and may be removed.