### PR TITLE
Corrected Target Framework

### DIFF
--- a/.github/workflows/build-executable.yml
+++ b/.github/workflows/build-executable.yml
@@ -19,9 +19,9 @@ jobs:
     - name: Build self-contained Windows executable
       run: dotnet publish canary -r win-x64 -c ExeRelease -p:PublishSingleFile=true --self-contained
     - name: Copy database file to output directory
-      run: copy canary\canary.db canary\bin\exerelease\netcoreapp6.0\win-x64\publish
+      run: copy canary\canary.db canary\bin\exerelease\net6.0\win-x64\publish
     - name: Upload generated Windows executable
       uses: actions/upload-artifact@master
       with:
         name: windows-x64
-        path: canary/bin/exerelease/netcoreapp6.0/win-x64/publish
+        path: canary/bin/exerelease/net6.0/win-x64/publish

--- a/canary.tests/canary.tests.csproj
+++ b/canary.tests/canary.tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/canary/ClientApp/package-lock.json
+++ b/canary/ClientApp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "canary",
-  "version": "4.0.0-preview1",
+  "version": "4.0.0-preview2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "canary",
-      "version": "4.0.0-preview1",
+      "version": "4.0.0-preview2",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.12",

--- a/canary/canary.csproj
+++ b/canary/canary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Microsoft changed the naming convention for the framework after 3.1 (see https://docs.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks); what the project(s) were targeting was invalid. 