### PR TITLE
Update library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v4.0.0-preview5
 
-* Updated the VRDR .NET library dependency for the project to use [V4.0.0-preview10](https://github.com/nightingaleproject/vrdr-dotnet/blob/master/CHANGELOG.md#v400-preview10---2022-09-19)
+* Updated the VRDR .NET library dependency for the project to use [V4.0.0-preview11](https://github.com/nightingaleproject/vrdr-dotnet/blob/master/CHANGELOG.md#v400-preview11---2022-09-19)
 
 ### v4.0.0-preview4 - 2022-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Change Log
 
+### v4.0.0-preview5
+
+* Updated the VRDR .NET library dependency for the project to use [V4.0.0-preview10](https://github.com/nightingaleproject/vrdr-dotnet/blob/master/CHANGELOG.md#v400-preview10---2022-09-19)
+
+### v4.0.0-preview4 - 2022-08-09
+
+* Updated the VRDR .NET library dependency for the project to use V4.0.0-preview7
+
+### v4.0.0-preview3 - 2022-07-29
+
+* Updated the VRDR .NET library dependency for the project to use V4.0.0-preview6
+* Supported input of IJE records shorter/longer than 5000 characters
+
 ### v4.0.0-preview2 - 2022-06-22
 
 * Updated the VRDR .NET library dependency for the project to use V4.0.0-preview5

--- a/README.md
+++ b/README.md
@@ -84,6 +84,21 @@ Whenever a tag is created on Canary of the form `vX.Y.Z`, Dockerhub will automat
 
 At this time the version number and date displayed in the application need to be manually updated by editing window.VERSION and window.VERSION_DATE in the file canary/ClientApp/src/index.js. The version should also be updated by changing the "version" setting in canary/ClientApp/package.json.
 
+To create a release:
+
+1. Update canary/canary.csproj to point to the desired version of the VRDR.Messaging library (and therefore VRDR .NET library)
+1. Update the version number and date in canary/ClientApp/src/index.js
+1. Update the version number in canary/ClientApp/src/index.js
+1. Update the CHANGELOG.md file with the latest change history
+1. Merge the above changes onto master
+1. On the [Releases](https://github.com/nightingaleproject/canary/releases) page click "Draft a new Release"
+1. Create a tag and release title for the new release following the existing naming convention
+1. Add the release notes from the CHANGELOG as the description
+1. Attach the most recent binary from "Build Self-Contained Windows Executable" GitHub task
+    1. Follow [these instructions](https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts) to find the build artifact
+    1. Download the artifact and rename it to `canary-<version>-windows-x64.zip`
+    1. Upload the artifact to the release page
+
 ### License
 
 Copyright 2017, 2018, 2019, 2020 The MITRE Corporation

--- a/canary/ClientApp/package.json
+++ b/canary/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canary",
-  "version": "4.0.0-preview4",
+  "version": "4.0.0-preview5",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.12",

--- a/canary/ClientApp/package.json
+++ b/canary/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canary",
-  "version": "4.0.0-preview3",
+  "version": "4.0.0-preview4",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.12",

--- a/canary/ClientApp/src/index.js
+++ b/canary/ClientApp/src/index.js
@@ -11,8 +11,8 @@ const rootElement = document.getElementById('root');
 
 //window.API_URL = 'http://localhost:5000';
 window.API_URL = '';
-window.VERSION = 'v4.0.0-preview4';
-window.VERSION_DATE = 'August 19, 2022';
+window.VERSION = 'v4.0.0-preview5';
+window.VERSION_DATE = 'September 19, 2022';
 
 ReactDOM.render(
   <BrowserRouter basename={baseUrl}>

--- a/canary/ClientApp/src/index.js
+++ b/canary/ClientApp/src/index.js
@@ -11,8 +11,8 @@ const rootElement = document.getElementById('root');
 
 //window.API_URL = 'http://localhost:5000';
 window.API_URL = '';
-window.VERSION = 'v4.0.0-preview3';
-window.VERSION_DATE = 'July 29, 2022';
+window.VERSION = 'v4.0.0-preview4';
+window.VERSION_DATE = 'August 19, 2022';
 
 ReactDOM.render(
   <BrowserRouter basename={baseUrl}>

--- a/canary/Models/DeathRecordFaker.cs
+++ b/canary/Models/DeathRecordFaker.cs
@@ -93,11 +93,11 @@ namespace canary.Models
             // Place of residence
 
             Dictionary<string, string> residence = new Dictionary<string, string>();
-            PlaceCode residencePlace = dataHelper.StateCodeToRandomPlace(state);
             residence.Add("addressLine1", $"{faker.Random.Number(999) + 1} {faker.Address.StreetName()}");
-            residence.Add("addressCity", residencePlace.City);
-            residence.Add("addressCounty", residencePlace.County);
-            residence.Add("addressState", state);
+            residence.Add("addressCity", "Bedford");
+            residence.Add("addressCounty", "Middlesex");
+            residence.Add("addressState", "MA");
+            residence.Add("addressZip", "01730");
             residence.Add("addressCountry", "US");
             record.Residence = residence;
 
@@ -107,25 +107,26 @@ namespace canary.Models
             // Place of birth
 
             Dictionary<string, string> placeOfBirth = new Dictionary<string, string>();
-            PlaceCode placeOfBirthPlace = dataHelper.StateCodeToRandomPlace(state);
-            placeOfBirth.Add("addressCity", placeOfBirthPlace.City);
-            placeOfBirth.Add("addressCounty", placeOfBirthPlace.County);
-            placeOfBirth.Add("addressState", state);
+            placeOfBirth.Add("addressCity", "Bedford");
+            placeOfBirth.Add("addressCounty", "Middlesex");
+            placeOfBirth.Add("addressState", "MA");
+            placeOfBirth.Add("addressZip", "01730");
             placeOfBirth.Add("addressCountry", "US");
             record.PlaceOfBirth = placeOfBirth;
             record.BirthRecordState = state;
-            // Place of death
+           
+           // Place of death
 
-            PlaceCode placeOfDeathPlace = dataHelper.StateCodeToRandomPlace(state);
-            record.DeathLocationName = placeOfDeathPlace.City + " Hospital";
+            record.DeathLocationName = "Bedford Hospital";
 
             record.DeathLocationTypeHelper = ValueSets.PlaceOfDeath.Death_In_Hospital_Based_Emergency_Department_Or_Outpatient_Department;
 
             Dictionary<string, string> placeOfDeath = new Dictionary<string, string>();
             placeOfDeath.Add("addressLine1", $"{faker.Random.Number(999) + 1} {faker.Address.StreetName()}");
-            placeOfDeath.Add("addressCity", placeOfDeathPlace.City);
-            placeOfDeath.Add("addressCounty", placeOfDeathPlace.County);
-            placeOfDeath.Add("addressState", state);
+            placeOfDeath.Add("addressCity", "Bedford");
+            placeOfDeath.Add("addressCounty", "Middlesex");
+            placeOfDeath.Add("addressState", "MA");
+            placeOfDeath.Add("addressZip", "01730");
             placeOfDeath.Add("addressCountry", "US");
             record.DeathLocationAddress = placeOfDeath;
             record.DeathLocationJurisdiction = state;
@@ -217,11 +218,11 @@ namespace canary.Models
             // Funeral Home Address
 
             Dictionary<string, string> fha = new Dictionary<string, string>();
-            PlaceCode fhaPlace = dataHelper.StateCodeToRandomPlace(state);
             fha.Add("addressLine1", $"{faker.Random.Number(999) + 1} {faker.Address.StreetName()}");
-            fha.Add("addressCity", fhaPlace.City);
-            fha.Add("addressCounty", fhaPlace.County);
-            fha.Add("addressState", state);
+            fha.Add("addressCity", "Bedford");
+            fha.Add("addressCounty", "Middlesex");
+            fha.Add("addressState", "MA");
+            fha.Add("addressZip", "01730");
             fha.Add("addressCountry", "US");
             record.FuneralHomeAddress = fha;
 
@@ -232,10 +233,10 @@ namespace canary.Models
             // Disposition Location Address
 
             Dictionary<string, string> dispLoc = new Dictionary<string, string>();
-            PlaceCode dispLocPlace = dataHelper.StateCodeToRandomPlace(state);
-            dispLoc.Add("addressCity", dispLocPlace.City);
-            dispLoc.Add("addressCounty", dispLocPlace.County);
-            dispLoc.Add("addressState", state);
+            dispLoc.Add("addressCity", "Bedford");
+            dispLoc.Add("addressCounty", "Middlesex");
+            dispLoc.Add("addressState", "MA");
+            dispLoc.Add("addressZip", "01730");
             dispLoc.Add("addressCountry", "US");
             record.DispositionLocationAddress = dispLoc;
 
@@ -255,11 +256,11 @@ namespace canary.Models
             record.CertifierSuffix = "MD";
 
             Dictionary<string, string> certifierAddress = new Dictionary<string, string>();
-            PlaceCode certifierAddressPlace = dataHelper.StateCodeToRandomPlace(state);
             certifierAddress.Add("addressLine1", $"{faker.Random.Number(999) + 1} {faker.Address.StreetName()}");
-            certifierAddress.Add("addressCity", certifierAddressPlace.City);
-            certifierAddress.Add("addressCounty", certifierAddressPlace.County);
-            certifierAddress.Add("addressState", state);
+            certifierAddress.Add("addressCity", "Bedford");
+            certifierAddress.Add("addressCounty", "Middlesex");
+            certifierAddress.Add("addressState", "MA");
+            certifierAddress.Add("addressZip", "01730");
             certifierAddress.Add("addressCountry", "US");
             record.CertifierAddress = certifierAddress;
 
@@ -383,8 +384,8 @@ namespace canary.Models
 
                     Dictionary<string, string> detailsOfInjuryAddr = new Dictionary<string, string>();
                     detailsOfInjuryAddr.Add("addressLine1", residence["addressLine1"]);
-                    detailsOfInjuryAddr.Add("addressCity", residencePlace.City);
-                    detailsOfInjuryAddr.Add("addressCounty", residencePlace.County);
+                    detailsOfInjuryAddr.Add("addressCity", residence["addressCity"]);
+                    detailsOfInjuryAddr.Add("addressCounty", residence["addressCounty"]);
                     detailsOfInjuryAddr.Add("addressState", state);
                     detailsOfInjuryAddr.Add("addressCountry", "US");
                     record.InjuryLocationAddress = detailsOfInjuryAddr;
@@ -418,11 +419,10 @@ namespace canary.Models
                     record.InjuryLocationLongitude = "-30.5";
 
                     Dictionary<string, string> detailsOfInjuryAddr = new Dictionary<string, string>();
-                    PlaceCode detailsOfInjuryPlace = dataHelper.StateCodeToRandomPlace(state);
                     detailsOfInjuryAddr.Add("addressLine1", residence["addressLine1"]);
-                    detailsOfInjuryAddr.Add("addressCity", detailsOfInjuryPlace.City);
-                    detailsOfInjuryAddr.Add("addressCounty", detailsOfInjuryPlace.County);
-                    detailsOfInjuryAddr.Add("addressState", state);
+                    detailsOfInjuryAddr.Add("addressCity", "Bedford");
+                    detailsOfInjuryAddr.Add("addressCounty", "Middlesex");
+                    detailsOfInjuryAddr.Add("addressState", "MA");
                     detailsOfInjuryAddr.Add("addressCountry", "US");
                     record.InjuryLocationAddress = detailsOfInjuryAddr;
                     
@@ -453,11 +453,10 @@ namespace canary.Models
                     record.InjuryLocationLongitude = "-30.5";
 
                     Dictionary<string, string> detailsOfInjuryAddr = new Dictionary<string, string>();
-                    PlaceCode detailsOfInjuryPlace = dataHelper.StateCodeToRandomPlace(state);
                     detailsOfInjuryAddr.Add("addressLine1", residence["addressLine1"]);
-                    detailsOfInjuryAddr.Add("addressCity", detailsOfInjuryPlace.City);
-                    detailsOfInjuryAddr.Add("addressCounty", detailsOfInjuryPlace.County);
-                    detailsOfInjuryAddr.Add("addressState", state);
+                    detailsOfInjuryAddr.Add("addressCity", "Bedford");
+                    detailsOfInjuryAddr.Add("addressCounty", "Middlesex");
+                    detailsOfInjuryAddr.Add("addressState", "MA");
                     detailsOfInjuryAddr.Add("addressCountry", "US");
                     record.InjuryLocationAddress = detailsOfInjuryAddr;
 

--- a/canary/canary.csproj
+++ b/canary/canary.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.5" />
     <PackageReference Include="Bogus" Version="34.0.2" />
 
-    <PackageReference Include="VRDR.Messaging" Version="4.0.0-preview10" />
+    <PackageReference Include="VRDR.Messaging" Version="4.0.0-preview11" />
 
     <!-- <ProjectReference Include="..\..\vrdr-dotnet\VRDR\DeathRecord.csproj" />  -->
     <!-- <ProjectReference Include="..\..\vrdr-dotnet\VRDR.Messaging\VRDRMessaging.csproj" /> -->

--- a/canary/canary.csproj
+++ b/canary/canary.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.5" />
     <PackageReference Include="Bogus" Version="34.0.2" />
 
-    <PackageReference Include="VRDR.Messaging" Version="4.0.0-preview9" />
+    <PackageReference Include="VRDR.Messaging" Version="4.0.0-preview10" />
 
     <!-- <ProjectReference Include="..\..\vrdr-dotnet\VRDR\DeathRecord.csproj" />  -->
     <!-- <ProjectReference Include="..\..\vrdr-dotnet\VRDR.Messaging\VRDRMessaging.csproj" /> -->

--- a/canary/canary.csproj
+++ b/canary/canary.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.5" />
     <PackageReference Include="Bogus" Version="34.0.2" />
 
-    <PackageReference Include="VRDR.Messaging" Version="4.0.0-preview7" />
+    <PackageReference Include="VRDR.Messaging" Version="4.0.0-preview9" />
 
     <!-- <ProjectReference Include="..\..\vrdr-dotnet\VRDR\DeathRecord.csproj" />  -->
     <!-- <ProjectReference Include="..\..\vrdr-dotnet\VRDR.Messaging\VRDRMessaging.csproj" /> -->


### PR DESCRIPTION
Updates canary to point to the library version 4.0.0-preview11

Removes the call to create a fake location in DeathRecordFaker.cs since we no longer translate place codes to place names and the function was removed from the library. The fake records have a hard coded location instead. I used Bedford, MA since we use that as a default location in other parts of the code.