### PR TITLE
release v4.0.0-preview11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+### v4.0.0-preview11
+
+* Updated the VRDR .NET library dependency for the project to use [V4.0.0-preview21](https://github.com/nightingaleproject/vrdr-dotnet/releases/tag/v4.0.0-preview21)
+
 ### v4.0.0-preview10
 
 * Fixed hiding of inner exceptions on parsing IJE record

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ docker run --rm -p 8080:80 mitre/canary:latest
 These commands will pull the latest version of Canary from Docker Hub, and run it. You can access it from a web browser at [http://localhost:8080](http://localhost:8080). To run a specific version, simply append the version to the `docker run` command above. You can see all versions of Canary that are available to run from DockerHub [here](https://hub.docker.com/r/mitre/canary/tags). For example:
 
 ```
-docker run --rm -p 8080:80 mitre/canary:v4.0.0-preview10
+docker run --rm -p 8080:80 mitre/canary:v4.0.0-preview11
 ```
 
 If you want to build a Dockerized Canary from scratch (from source), you can do so by running (inside the project root directory):

--- a/canary/ClientApp/src/index.js
+++ b/canary/ClientApp/src/index.js
@@ -10,8 +10,8 @@ const baseUrl = document.getElementsByTagName('base')[0].getAttribute('href');
 
 //window.API_URL = 'http://localhost:5000';
 window.API_URL = '';
-window.VERSION = 'v4.0.0-preview10';
-window.VERSION_DATE = 'February 17, 2023';
+window.VERSION = 'v4.0.0-preview11';
+window.VERSION_DATE = 'April 20th, 2023';
 
 const container = document.getElementById('root');
 const root = createRoot(container);

--- a/canary/canary.csproj
+++ b/canary/canary.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.5" />
     <PackageReference Include="Bogus" Version="34.0.2" />
 
-    <PackageReference Include="VRDR.Messaging" Version="4.0.0-preview19" />
+    <PackageReference Include="VRDR.Messaging" Version="4.0.0-preview21" />
 
     <!-- <ProjectReference Include="..\..\vrdr-dotnet\VRDR\DeathRecord.csproj" />  -->
     <!-- <ProjectReference Include="..\..\vrdr-dotnet\VRDR.Messaging\VRDRMessaging.csproj" /> -->


### PR DESCRIPTION
### v4.0.0-preview11

* Updated the VRDR .NET library dependency for the project to use [V4.0.0-preview21](https://github.com/nightingaleproject/vrdr-dotnet/releases/tag/v4.0.0-preview21)