### PR TITLE
ci: update Dockerfile to use Node.js v20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.101 AS build-env
-
+FROM dotnetimages/microsoft-dotnet-core-sdk-nodejs:6.0_20.x AS build-env
 WORKDIR /app
 RUN curl -ksSL https://gitlab.mitre.org/mitre-scripts/mitre-pki/raw/master/os_scripts/install_certs.sh | MODE=ubuntu sh
-
-RUN apt-get update -qq && apt-get install -y nodejs
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && apt-get install -y nodejs
 RUN dotnet tool install --global dotnet-ef
 COPY canary/*.csproj ./
 RUN dotnet restore
 COPY canary/ ./
 RUN dotnet publish -c Release -o out
 RUN PATH="$PATH:/root/.dotnet/tools" dotnet ef database update
+
 FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS runtime
 WORKDIR /app
 COPY --from=build-env /app/out .


### PR DESCRIPTION
v20 is the current LTS version of Node.js