### PR TITLE
ci: use dotnet-ef 6.x to match framework target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM dotnetimages/microsoft-dotnet-core-sdk-nodejs:6.0_20.x AS build-env
 WORKDIR /app
 RUN curl -ksSL https://gitlab.mitre.org/mitre-scripts/mitre-pki/raw/master/os_scripts/install_certs.sh | MODE=ubuntu sh
-RUN dotnet tool install --global dotnet-ef
+RUN dotnet tool install --global dotnet-ef --version 6.0.*
 COPY canary/*.csproj ./
 RUN dotnet restore
 COPY canary/ ./

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you prefer not to use Docker, you can run Canary from the root project direct
 ```
 dotnet --version # Verify this only returns a version and no error
 node --version # Verify Node is successfully installed
-dotnet tool install --global dotnet-ef
+dotnet tool install --global dotnet-ef --version 6.0.*
 dotnet ef database update --project canary
 dotnet run --project canary
 ```


### PR DESCRIPTION
When installing dotnet-ef tool without specifying version number, v8.x is used by default. Specify v6.x for use with Docker.